### PR TITLE
Add cookie secret

### DIFF
--- a/app/sessions.ts
+++ b/app/sessions.ts
@@ -1,9 +1,12 @@
 import { createCookieSessionStorage } from "@remix-run/node";
+import { z } from "zod";
+
+const cookieSecret = z.string().parse(process.env.COOKIE_SECRET);
 
 export const { getSession, commitSession, destroySession } =
 	createCookieSessionStorage({
 		cookie: {
 			name: "__session",
-			secrets: [],
+			secrets: [cookieSecret],
 		},
 	});


### PR DESCRIPTION
We're supposed to "encrypt" the session cookie with a secret otherwise stuff can be manipulated, I think.